### PR TITLE
fix list head parameter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .list()
         // Optional Parameters
         .state(params::State::Open)
-        .head(head_str)
+        .head(format!("{}:{}", owner, head_str))
         .base(base_str)
         .sort(params::pulls::Sort::Created)
         .direction(params::Direction::Descending)


### PR DESCRIPTION
https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests

> Filter pulls by head user or head organization and branch name in the format of user:ref-name or organization:ref-name. For example: github:new-script-format or octocat:test-branch.